### PR TITLE
Fix nonexhaustive switch breaking compilation with swift-syntax-binary

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -292,6 +292,8 @@ extension AttributeListSyntax.Element {
       if let availability = ifConfig.availability {
         return .ifConfigDecl(availability)
       }
+    default:
+      return nil
     }
     return nil
   }


### PR DESCRIPTION
The fix is required to enable _swift-dependencies_ to be used with the prebuilt version of _swift-syntax_. Compilation breaks on `DependencyClientMacro:116:9` with `Switch covers known cases, but 'AccessorBlockSyntax.Accessors' may have additional unknown values` error message. It is necessary to define [exhaustive switch cases](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md) for unfrozen enums because compilation, unaware of possible enum changes due to ABI stability, results in an error instead of a warning, unlike compilation from sources.